### PR TITLE
Suppression hgroup

### DIFF
--- a/css/knacss.css
+++ b/css/knacss.css
@@ -33,8 +33,7 @@ label,
 textarea,
 caption,
 details, 
-figure, 
-hgroup {
+figure {
 	font-size: 1em; /* equiv 14px */
 	line-height: 1.5;
 	margin: .75em 0 0;


### PR DESCRIPTION
Balise hgroup abandonnée. http://lists.w3.org/Archives/Public/public-html-admin/2013Apr/0003.html
