### PR TITLE
add package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+    "name": "KNACSS",
+    "version": "4.0.3",
+    "homepage": "http://www.knacss.com/",
+    "bugs": "https://github.com/raphaelgoetter/KNACSS/issues",
+    "author": [
+        "Raphaël GOETTER, Alsacreations"
+    ],
+    "contributors": [
+        "Raphaël GOETTER, Alsacreations"
+    ],
+    "description": "KNACSS is a minimalist, responsive and extensible style sheet to kick-start your HTML / CSS projects. It relies on common best practices and experience on the topic.",
+    "main": "css/knacss.css",
+    "keywords": [
+        "css", "framework", "reset", "responsive", "less", "sass", "rwd", "boilerplate", "workflow"
+    ],
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/raphaelgoetter/KNACSS"
+    },
+    "license": "WTFPL",
+    "dependencies": {},
+    "engines": {}
+}


### PR DESCRIPTION
Sur le même principe que la PR #41. je me suis inspiré du bower.

éventuellement, il est possible d'ajouter des dépendances pour par exemple avoir sass et less directement, mais ce nest pas à moi d'en décider.

En l'état, ça permet d'installer KNACSS en faisant un npm install raphaelgoetter/KNACSS. Idéalement, il faudrait le publier pour qu'on puisse faire directement un npm install knacss

Pour cela, il faut s'[inscrire](https://www.npmjs.org/signup) puis faire npm publish .