### PR TITLE
Fix for double abbr in Firefox

### DIFF
--- a/sass/_01a-normalize.scss
+++ b/sass/_01a-normalize.scss
@@ -107,6 +107,7 @@ a:hover {
  */
 
 abbr[title] {
+  text-decoration: none;
   border-bottom: 1px dotted;
 }
 


### PR DESCRIPTION
Firefox is styling abbr/acronym by default with ```text-decoration: dotted underline``` https://developer.mozilla.org/en-US/Firefox/Releases/40/Site_Compatibility
This fix avoids a double border-bottom.