### PR TITLE
Fix for double abbr in Firefox

### DIFF
--- a/css/knacss-unminified.css
+++ b/css/knacss-unminified.css
@@ -95,6 +95,7 @@ a:hover {
  * Address styling not present in IE 8/9/10/11, Safari, and Chrome.
  */
 abbr[title] {
+  text-decoration: none;
   border-bottom: 1px dotted;
 }
 /**


### PR DESCRIPTION
Firefox is styling abbr/acronym by default with ```text-decoration: dotted underline``` https://developer.mozilla.org/en-US/Firefox/Releases/40/Site_Compatibility
This fix avoids a double border-bottom.